### PR TITLE
make the Match class public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .classpath
 .project
 .settings/
+.idea/
 				

--- a/src/main/java/de/reffle/jfsdict/levenshtein/Match.java
+++ b/src/main/java/de/reffle/jfsdict/levenshtein/Match.java
@@ -1,6 +1,6 @@
 package de.reffle.jfsdict.levenshtein;
 
-class Match {
+public class Match {
   public String match;
   public int levDistance;
   public int annotation;


### PR DESCRIPTION
being part of the public API of the MatchReceiver it's important to be able to access the Match elements